### PR TITLE
Implement weapon propagation combat

### DIFF
--- a/codex.js
+++ b/codex.js
@@ -64,6 +64,7 @@
     const CATEGORY_DEFINITIONS = [
         ['new-player', 'New Player'],
         ['combat', 'Combat'],
+        ['weapon-types', 'Weapon Types'],
         ['damage-types', 'Damage Types'],
         ['passives', 'Passives'],
         ['debuffs', 'Debuffs'],
@@ -100,6 +101,108 @@
     function renderStaticPage(container, page) {
         appendPageTitle(container, page.title);
         page.sections.forEach(([subtitle, text]) => appendTextSection(container, subtitle, text));
+    }
+
+    function renderWeaponTypes(container) {
+        appendPageTitle(container, 'Weapon Types');
+        const tabs = document.createElement('nav');
+        tabs.className = 'codex-subpages';
+        const page = document.createElement('div');
+        page.className = 'codex-subpage-content';
+        container.append(tabs, page);
+
+        const definitions = window.coreboundWeaponTaxonomy?.families || {};
+        const profiles = window.coreboundPropagation?.profiles || {};
+        const familyOrder = ['blades', 'impact', 'sidearms', 'rifles', 'projectors', 'ordnance', 'conduits'];
+
+        const renderOverview = () => {
+            page.replaceChildren();
+            appendTextSection(
+                page,
+                'Weapon Families',
+                'A weapon family is its stable mechanical identity. Display names and tags may vary, but the family determines its intrinsic propagation behavior.'
+            );
+            const grid = document.createElement('div');
+            grid.className = 'codex-weapon-grid';
+            for (const family of familyOrder) {
+                const definition = definitions[family];
+                const profile = profiles[family];
+                const card = document.createElement('section');
+                card.className = 'codex-weapon-family';
+                const heading = document.createElement('h3');
+                heading.textContent = definition?.label || titleCase(family);
+                const description = document.createElement('p');
+                description.textContent = definition?.description || 'No chassis notes recorded.';
+                const propagation = document.createElement('strong');
+                propagation.textContent = `${profile?.label || 'Propagation'} · ${Math.round(Number(profile?.damageCoefficient || 0) * 100)}% secondary damage`;
+                card.append(heading, description, propagation);
+                grid.appendChild(card);
+            }
+            page.appendChild(grid);
+        };
+
+        const renderPropagation = () => {
+            page.replaceChildren();
+            appendTextSection(
+                page,
+                'Propagation',
+                'Every equipped weapon hits its primary target and one additional target when possible. Propagation Targets adds more secondaries, to a maximum of five. Secondary hits reuse the original damage roll and critical result, then check each target’s defenses independently.'
+            );
+            appendTextSection(
+                page,
+                'Triggered Effects',
+                'All propagation types use a 30% trigger coefficient for inherent debuffs and other on-hit or on-critical effects.'
+            );
+            const table = document.createElement('table');
+            table.className = 'codex-propagation-table';
+            table.innerHTML = '<thead><tr><th>Weapon family</th><th>Propagation</th><th>Damage</th><th>Targeting</th></tr></thead>';
+            const body = document.createElement('tbody');
+            const targeting = {
+                blades: 'Cleave through the target row, then overflow to the opposite row.',
+                impact: 'Splash through orthogonally connected enemies.',
+                sidearms: 'Fire sequentially at random unique enemies.',
+                rifles: 'Chain to an adjacent living enemy after each hit; later chains may revisit a target.',
+                projectors: 'Fire sequentially at random unique enemies.',
+                ordnance: 'Detonate into random unique enemies.',
+                conduits: 'Pulse into random unique enemies at once.'
+            };
+            for (const family of familyOrder) {
+                const definition = definitions[family];
+                const profile = profiles[family];
+                const row = document.createElement('tr');
+                [
+                    definition?.label || titleCase(family),
+                    profile?.label || '—',
+                    `${Math.round(Number(profile?.damageCoefficient || 0) * 100)}%`,
+                    targeting[family]
+                ].forEach(value => {
+                    const cell = document.createElement('td');
+                    cell.textContent = value;
+                    row.appendChild(cell);
+                });
+                body.appendChild(row);
+            }
+            table.appendChild(body);
+            page.appendChild(table);
+        };
+
+        const subpages = [
+            ['overview', 'Overview', renderOverview],
+            ['propagation', 'Propagation', renderPropagation]
+        ];
+        const displaySubpage = (id, render) => {
+            tabs.querySelectorAll('button').forEach(button => button.classList.toggle('active', button.dataset.subpage === id));
+            render();
+        };
+        subpages.forEach(([id, label, render]) => {
+            const button = document.createElement('button');
+            button.type = 'button';
+            button.dataset.subpage = id;
+            button.textContent = label;
+            button.addEventListener('click', () => displaySubpage(id, render));
+            tabs.appendChild(button);
+        });
+        displaySubpage('overview', renderOverview);
     }
 
     function renderDebuffs(container) {
@@ -457,6 +560,7 @@
             });
             if (categoryId === 'debuffs') renderDebuffs(content);
             else if (categoryId === 'enemies') renderEnemies(content);
+            else if (categoryId === 'weapon-types') renderWeaponTypes(content);
             else renderStaticPage(content, STATIC_PAGES[categoryId]);
         };
 

--- a/combatController.js
+++ b/combatController.js
@@ -290,10 +290,6 @@ function combatLoop() {
     const now = Date.now();
     const deltaTime = Math.max(0, (now - lastCombatLoopTime) / 1000);
     lastCombatLoopTime = now;
-    // Propagation resolves atomically before it is drawn. Pause later combat
-    // events while that frozen record is presented so a subsequent DOT tick or
-    // attack cannot appear to land ahead of an in-flight propagation hit.
-    if (typeof isPropagationPresentationBusy === 'function' && isPropagationPresentationBusy()) return;
     processEnemyTaunts(deltaTime);
 
     if (player) {
@@ -303,7 +299,6 @@ function combatLoop() {
             playerAttackTimer = 0;
             refreshPlayerAttackInterval();
             if (getEffectivePlayerTarget()) playerAttack();
-            if (typeof isPropagationPresentationBusy === 'function' && isPropagationPresentationBusy()) return;
         }
         setAttackProgressBar('player', Math.min((playerAttackTimer / playerNextAttackTime) * 100, 100));
     }

--- a/combatController.js
+++ b/combatController.js
@@ -260,6 +260,7 @@ function startCombat() {
         return;
     }
 
+    if (typeof cancelPropagationPresentations === 'function') cancelPropagationPresentations();
     preparePlayerForCombat();
     if (typeof resetCombatStyleState === 'function') resetCombatStyleState(player);
     isCombatActive = true;
@@ -289,6 +290,10 @@ function combatLoop() {
     const now = Date.now();
     const deltaTime = Math.max(0, (now - lastCombatLoopTime) / 1000);
     lastCombatLoopTime = now;
+    // Propagation resolves atomically before it is drawn. Pause later combat
+    // events while that frozen record is presented so a subsequent DOT tick or
+    // attack cannot appear to land ahead of an in-flight propagation hit.
+    if (typeof isPropagationPresentationBusy === 'function' && isPropagationPresentationBusy()) return;
     processEnemyTaunts(deltaTime);
 
     if (player) {
@@ -298,6 +303,7 @@ function combatLoop() {
             playerAttackTimer = 0;
             refreshPlayerAttackInterval();
             if (getEffectivePlayerTarget()) playerAttack();
+            if (typeof isPropagationPresentationBusy === 'function' && isPropagationPresentationBusy()) return;
         }
         setAttackProgressBar('player', Math.min((playerAttackTimer / playerNextAttackTime) * 100, 100));
     }
@@ -363,6 +369,7 @@ function resetEncounterState() {
 
 function stopCombat(reason) {
     if (!isCombatActive && !isDelveInProgress && reason !== 'delveCompleted') return;
+    if (typeof cancelPropagationPresentations === 'function') cancelPropagationPresentations();
     if (isCombatActive) {
         isCombatActive = false;
         clearInterval(combatInterval);

--- a/combatResolution.js
+++ b/combatResolution.js
@@ -54,7 +54,8 @@ function runIncomingHitDebuffs(attacker, defender, damageResult) {
 }
 
 function tryApplySeveredLimbFromCritical(attacker, defender) {
-    const chance = Math.max(0, Number(attacker?.totalStats?.severedLimbChance || 0));
+    const triggerCoefficient = Math.max(0, Number(attacker?._activeSkillProcCoefficient ?? 1));
+    const chance = Math.max(0, Number(attacker?.totalStats?.severedLimbChance || 0)) * triggerCoefficient;
     if (!defender || chance <= 0 || Math.random() * 100 >= chance) return false;
     return typeof applyDebuff === 'function'
         ? applyDebuff(defender, 'severedLimb', attacker)
@@ -155,23 +156,20 @@ function executeEquippedSkill(attacker, defender) {
 
             applyDamage(damageResult);
 
-            if (defender.currentHealth <= 0) {
-                lastDamageResult = damageResult;
-                aggregateTotal += damageResult.total;
-                for (const [type, amount] of Object.entries(damageResult.damage || {})) {
-                    aggregateDamage[type] = (aggregateDamage[type] || 0) + amount;
+            if (defender.currentHealth > 0 && attacker && defender) {
+                runIncomingHitDebuffs(attacker, defender, damageResult);
+                if (isCombatActive && attacker && defender) {
+                    runSkillHitProcs(attacker, defender, damageResult, profile, hit);
+                    if (typeof recordCombatStyleHit === 'function') recordCombatStyleHit(profile, damageResult);
                 }
-                aggregateCritical = aggregateCritical || damageResult.isCritical;
-                break;
             }
 
-            if (!attacker || !defender) break;
+            // Weapon propagation is resolved from this hit's immutable roll and
+            // critical result even when the primary target was defeated.
+            if (attacker?.isPlayer && typeof resolveWeaponPropagation === 'function') {
+                resolveWeaponPropagation(attacker, defender, damageResult, profile, hit);
+            }
 
-            runIncomingHitDebuffs(attacker, defender, damageResult);
-            if (!isCombatActive || !attacker || !defender) break;
-
-            runSkillHitProcs(attacker, defender, damageResult, profile, hit);
-            if (typeof recordCombatStyleHit === 'function') recordCombatStyleHit(profile, damageResult);
             lastDamageResult = damageResult;
             aggregateTotal += damageResult.total;
             aggregateCritical ||= damageResult.isCritical;
@@ -179,7 +177,7 @@ function executeEquippedSkill(attacker, defender) {
                 aggregateDamage[damageType] = (aggregateDamage[damageType] || 0) + amount;
             }
 
-            if (!defender) break;
+            if (!defender || defender.currentHealth <= 0 || !isCombatActive) break;
         }
 
         attacker._activeSkillDebuffBonus = 0;

--- a/combatSchema.js
+++ b/combatSchema.js
@@ -263,6 +263,16 @@ function scaleDamagePacket(packet, multiplier) {
         damage[type] = Math.round(amount * scale * 10) / 10;
     }
 
+    const metadata = { ...packet.metadata };
+    if (metadata.unmitigatedDamage && typeof metadata.unmitigatedDamage === 'object') {
+        metadata.unmitigatedDamage = Object.fromEntries(
+            Object.entries(metadata.unmitigatedDamage).map(([type, amount]) => [
+                type,
+                Math.max(0, toFiniteCombatNumber(amount) * scale)
+            ])
+        );
+    }
+
     return createDamagePacket({
         source: packet.source,
         target: packet.target,
@@ -274,7 +284,7 @@ function scaleDamagePacket(packet, multiplier) {
         mitigated: packet.mitigated,
         tags: packet.tags,
         flags: packet.flags,
-        metadata: packet.metadata
+        metadata
     });
 }
 

--- a/combatUI.js
+++ b/combatUI.js
@@ -126,6 +126,7 @@ function updateEnemyStatsDisplay() {
             selected ? 'selected' : '',
             forced ? 'taunting' : '',
             candidate.currentHealth <= 0 ? 'defeated' : '',
+            propagationPresentationPendingIds.has(candidate._combatId) ? 'propagation-pending' : '',
             candidate.isEmpowered ? 'empowered' : ''
         ].filter(Boolean).join(' ');
         card.disabled = candidate.currentHealth <= 0;
@@ -580,3 +581,180 @@ function initializeCombatLogPopout() {
 }
 
 window.setDelveCombatUIActive = setDelveCombatUIActive;
+
+// ---------------------------------------------------------------------------
+// Propagation presentation queue
+// ---------------------------------------------------------------------------
+
+const propagationPresentationPendingIds = new Set();
+let propagationPresentationQueue = [];
+let propagationPresentationActive = false;
+let propagationPresentationGeneration = 0;
+let propagationPresentationTimer = null;
+
+function getPropagationPresentationAnchor(entity) {
+    if (entity?.isPlayer) return document.getElementById('player-stats');
+    return [...document.querySelectorAll('.enemy-combat-card')]
+        .find(card => card.dataset.combatId === entity?._combatId) || null;
+}
+
+function capturePropagationFormationSnapshot(attacker, primaryTarget) {
+    const stage = document.getElementById('delve-combat-stage');
+    if (!stage) return null;
+    const stageRect = stage.getBoundingClientRect();
+    const anchors = {};
+    const entities = [attacker, primaryTarget, ...(Array.isArray(encounterEnemies) ? encounterEnemies : [])];
+    for (const entity of entities) {
+        if (!entity) continue;
+        const key = entity.isPlayer ? 'player' : String(entity._combatId || entity.id || entity.name);
+        if (anchors[key]) continue;
+        const element = getPropagationPresentationAnchor(entity);
+        if (!element) continue;
+        const rect = element.getBoundingClientRect();
+        anchors[key] = Object.freeze({
+            x: rect.left - stageRect.left + rect.width / 2,
+            y: rect.top - stageRect.top + rect.height / 2,
+            width: rect.width,
+            height: rect.height
+        });
+    }
+    return Object.freeze({ anchors: Object.freeze(anchors) });
+}
+
+function createPropagationEffect(className, style = {}) {
+    const layer = document.getElementById('propagation-effects-layer');
+    if (!layer) return null;
+    const effect = document.createElement('span');
+    effect.className = `propagation-effect ${className}`;
+    Object.assign(effect.style, style);
+    layer.appendChild(effect);
+    return effect;
+}
+
+function createPropagationLine(origin, target, type) {
+    const deltaX = target.x - origin.x;
+    const deltaY = target.y - origin.y;
+    const distance = Math.hypot(deltaX, deltaY);
+    return createPropagationEffect(`propagation-line propagation-${type}`, {
+        left: `${origin.x}px`,
+        top: `${origin.y}px`,
+        width: `${distance}px`,
+        transform: `rotate(${Math.atan2(deltaY, deltaX)}rad)`
+    });
+}
+
+function renderPropagationImpact(sequence, event) {
+    const target = sequence.snapshot?.anchors?.[event.targetId];
+    if (!target) return;
+    const impact = createPropagationEffect(`propagation-impact propagation-${event.type}`, {
+        left: `${target.x}px`,
+        top: `${target.y}px`
+    });
+    const number = createPropagationEffect(`propagation-damage${event.critical ? ' critical' : ''}`, {
+        left: `${target.x}px`,
+        top: `${target.y - 20}px`
+    });
+    if (number) number.textContent = `-${Math.round(event.damage)}${event.critical ? '!' : ''}`;
+    setTimeout(() => impact?.remove(), 380);
+    setTimeout(() => number?.remove(), 620);
+}
+
+function renderSequentialPropagationEvent(sequence, event, done) {
+    const origin = sequence.snapshot?.anchors?.[event.originId];
+    const target = sequence.snapshot?.anchors?.[event.targetId];
+    if (!origin || !target) {
+        done();
+        return;
+    }
+    const line = createPropagationLine(origin, target, event.type);
+    const duration = event.type === 'chain' ? 35 : event.type === 'cleave' ? 45 : 55;
+    propagationPresentationTimer = setTimeout(() => {
+        line?.classList.add('arrived');
+        renderPropagationImpact(sequence, event);
+        propagationPresentationTimer = setTimeout(() => {
+            line?.remove();
+            done();
+        }, event.type === 'chain' ? 15 : 25);
+    }, duration);
+}
+
+function playPropagationSequence(sequence, complete) {
+    if (!sequence?.events?.length || !sequence.snapshot?.anchors) {
+        complete();
+        return;
+    }
+    const simultaneous = sequence.profile.id === 'nova' || sequence.profile.id === 'detonation';
+    if (simultaneous) {
+        const primary = sequence.snapshot.anchors[sequence.primaryTargetId];
+        const pulse = primary ? createPropagationEffect(`propagation-pulse propagation-${sequence.profile.id}`, {
+            left: `${primary.x}px`, top: `${primary.y}px`
+        }) : null;
+        const lines = sequence.events.map(event => {
+            const origin = sequence.snapshot.anchors[event.originId];
+            const target = sequence.snapshot.anchors[event.targetId];
+            return origin && target ? createPropagationLine(origin, target, event.type) : null;
+        });
+        propagationPresentationTimer = setTimeout(() => {
+            sequence.events.forEach(event => renderPropagationImpact(sequence, event));
+            lines.forEach(line => line?.classList.add('arrived'));
+            propagationPresentationTimer = setTimeout(() => {
+                pulse?.remove();
+                lines.forEach(line => line?.remove());
+                complete();
+            }, 120);
+        }, 80);
+        return;
+    }
+    let index = 0;
+    const next = () => {
+        if (index >= sequence.events.length) {
+            complete();
+            return;
+        }
+        renderSequentialPropagationEvent(sequence, sequence.events[index++], next);
+    };
+    next();
+}
+
+function runNextPropagationPresentation() {
+    if (propagationPresentationActive || propagationPresentationQueue.length === 0) return;
+    propagationPresentationActive = true;
+    const generation = propagationPresentationGeneration;
+    const queued = propagationPresentationQueue.shift();
+    playPropagationSequence(queued.sequence, () => {
+        if (generation !== propagationPresentationGeneration) return;
+        for (const event of queued.sequence.events) propagationPresentationPendingIds.delete(event.targetId);
+        queued.onComplete?.();
+        propagationPresentationActive = false;
+        if (typeof updateEnemyStatsDisplay === 'function') updateEnemyStatsDisplay();
+        runNextPropagationPresentation();
+    });
+}
+
+function queuePropagationPresentation(sequence, onComplete = null) {
+    for (const event of sequence?.events || []) {
+        if (event.targetDefeated) propagationPresentationPendingIds.add(event.targetId);
+    }
+    propagationPresentationQueue.push({ sequence, onComplete });
+    if (typeof updateEnemyStatsDisplay === 'function') updateEnemyStatsDisplay();
+    runNextPropagationPresentation();
+}
+
+function cancelPropagationPresentations() {
+    propagationPresentationGeneration++;
+    if (propagationPresentationTimer) clearTimeout(propagationPresentationTimer);
+    propagationPresentationTimer = null;
+    propagationPresentationQueue = [];
+    propagationPresentationActive = false;
+    propagationPresentationPendingIds.clear();
+    document.getElementById('propagation-effects-layer')?.replaceChildren();
+}
+
+function isPropagationPresentationBusy() {
+    return propagationPresentationActive || propagationPresentationQueue.length > 0;
+}
+
+window.capturePropagationFormationSnapshot = capturePropagationFormationSnapshot;
+window.queuePropagationPresentation = queuePropagationPresentation;
+window.cancelPropagationPresentations = cancelPropagationPresentations;
+window.isPropagationPresentationBusy = isPropagationPresentationBusy;

--- a/contentSchema.js
+++ b/contentSchema.js
@@ -16,6 +16,7 @@ const CONTENT_PASSIVE_STAT_KEYS = new Set([
     'healthRegen', 'precision', 'deflection', 'defenseTypes', 'armorEfficiency',
     'weaponEfficiency', 'bionicEfficiency', 'bionicSync', 'comboAttack', 'comboEffectiveness',
     'additionalComboAttacks', 'severedLimbChance', 'maxSeveredLimbs', 'maxSeepingWoundStacks',
+    'propagationTargets',
     'damageRollFloorBonus', 'debuffChanceBonus', 'debuffDurationBonus', 'directDamageMultiplier',
     'dotDamageMultiplier', 'damageVsDebuffed', 'damageTakenReduction', 'armorPenetration',
     'attackTimeModifier', ...CONTENT_CONDITIONAL_PASSIVE_KEYS

--- a/debuffs.js
+++ b/debuffs.js
@@ -774,7 +774,8 @@ function tryApplyDebuffFromDamage(source, target, damageInfo) {
     }
     debuffChance += Number(source?.totalStats?.debuffChanceBonus || 0);
     debuffChance -= Math.max(0, Number(target?.totalStats?.statusResistance || 0));
-    debuffChance = Math.min(1, Math.max(0, debuffChance));
+    const triggerCoefficient = Math.max(0, Number(source?._activeSkillProcCoefficient ?? 1));
+    debuffChance = Math.min(1, Math.max(0, debuffChance * triggerCoefficient));
     const shouldApply = shouldApplyDebuff(debuffChance);
     console.log(`tryApplyDebuffFromDamage: shouldApplyDebuff() returned ${shouldApply}`);
     

--- a/delveUI.js
+++ b/delveUI.js
@@ -483,35 +483,12 @@ function displayAdventureLocations() {
         searchInput.addEventListener('input', updateLocationDisplay);
         filterSelect.addEventListener('change', updateLocationDisplay);
 
-        // Now create the scrollable location grid
+        // Let the location grid use its natural height. The old internal
+        // viewport was sized for a denser card layout that no longer exists.
         const locationScrollContainer = document.createElement('div');
         locationScrollContainer.className = 'locations-scroll-container';
-        locationScrollContainer.style.overflow = 'auto';
-        locationScrollContainer.style.maxHeight = '400px';
-        locationScrollContainer.style.paddingRight = '5px';
         locationScrollContainer.style.zIndex = '2';
         locationScrollContainer.style.position = 'relative';
-
-        // Custom scrollbar styling
-        const scrollbarStyle = document.createElement('style');
-        scrollbarStyle.textContent = `
-            .locations-scroll-container::-webkit-scrollbar {
-                width: 8px;
-            }
-            .locations-scroll-container::-webkit-scrollbar-track {
-                background: rgba(0, 20, 40, 0.5);
-                border-radius: 4px;
-            }
-            .locations-scroll-container::-webkit-scrollbar-thumb {
-                background: #0096c7;
-                border-radius: 4px;
-                box-shadow: 0 0 5px rgba(0, 150, 199, 0.5);
-            }
-            .locations-scroll-container::-webkit-scrollbar-thumb:hover {
-                background: #00b4d8;
-            }
-        `;
-        document.head.appendChild(scrollbarStyle);
 
         interfaceContainer.appendChild(locationScrollContainer);
 

--- a/global.js
+++ b/global.js
@@ -62,6 +62,7 @@ const playerBaseStats = {
     comboAttack: 0,         // % chance to strike additional time after initial hit
     comboEffectiveness: 0,  // Increases damage dealt by combo attacks (base 20%)
     additionalComboAttacks: 0, // Number of additional combo hits beyond the first
+    propagationTargets: 0, // Additional targets beyond each weapon family's intrinsic target
     // Mastery system - increases damage for specific damage types
     kineticMastery: 0,      // Increases kinetic damage
     slashingMastery: 0,     // Increases slashing damage

--- a/index.html
+++ b/index.html
@@ -228,6 +228,7 @@
             <h3 id="delve-locations-heading">Delve Locations</h3>
             <div id="adventure-locations"></div>
             <div id="delve-combat-stage" class="delve-combat-stage hidden" aria-hidden="true">
+                <div id="propagation-effects-layer" class="propagation-effects-layer" aria-hidden="true"></div>
                 <div class="combat-stage-tools" aria-label="Delve utilities">
                     <button id="delve-bag-toggle" class="combat-stage-tool" type="button" aria-expanded="false">Open Bag</button>
                     <button id="combat-log-toggle" class="combat-stage-tool" type="button" aria-expanded="false">Combat Log</button>

--- a/inventory.js
+++ b/inventory.js
@@ -696,6 +696,7 @@ function renderEquipmentStatsPanel() {
             ${sectionRow('Crit Multiplier', `${(total.criticalMultiplier || 0).toFixed(2)}x`)}
             ${sectionRow('Precision', asInt(total.precision))}
             ${sectionRow('Deflection', asInt(total.deflection))}
+            ${sectionRow('Propagation Targets', Math.min(5, 1 + asInt(total.propagationTargets)))}
         </div>
         <div class="equipment-stat-section">
             <div class="equipment-stat-section-title">Damage Per Second</div>

--- a/passives.js
+++ b/passives.js
@@ -974,6 +974,88 @@ function createPassiveTree() {
         link(connector.id, closestCrossing.toId);
     }
 
+    // Every damage sector owns one dedicated propagation wheel. Add these
+    // after arterial routing so generated road repair cannot absorb a wheel
+    // node into the highway or sever an existing cluster entrance.
+    PASSIVE_TREE_SECTOR_ORDER.forEach((sectorId, sectorIndex) => {
+        const sector = PASSIVE_SECTOR_DEFINITIONS[sectorId];
+        const { travelIds } = sectorClusterIds[sectorId];
+        const propagationEntryId = travelIds[9];
+        const propagationEntry = authoredNodeById.get(propagationEntryId);
+        const routeLength = 330;
+        // These seven spoke directions are deliberately authored to occupy the
+        // open pocket beside each sector's tenth arterial node.
+        const direction = passivePolarPosition(1, 180 + sectorIndex * 45);
+        const placement = {
+            direction,
+            center: {
+                x: propagationEntry.x + direction.x * routeLength / 2,
+                y: propagationEntry.y + direction.y * routeLength / 2
+            }
+        };
+        const awayX = placement.direction.x;
+        const awayY = placement.direction.y;
+        const perpendicularX = -awayY;
+        const perpendicularY = awayX;
+        const propagationNotableId = `${sectorId}-propagation-notable`;
+        const propagationNotablePosition = {
+            x: Math.round(propagationEntry.x + awayX * routeLength),
+            y: Math.round(propagationEntry.y + awayY * routeLength)
+        };
+        const propagationMinorEffects = { damageTypes: { [sector.damageType]: 8 } };
+        const createPropagationRoute = (side, count) => {
+            const routeIds = [];
+            for (let index = 1; index <= count; index++) {
+                const progress = index / (count + 1);
+                const arc = Math.sin(progress * Math.PI) * (side === 'short' ? 72 : -82);
+                const id = `${sectorId}-propagation-${side}-${index}`;
+                addNode({
+                    id,
+                    name: `${sector.label} Propagation`,
+                    description: `8% increased ${sector.label} damage on the route to the sector's propagation notable.`,
+                    sector: sectorId,
+                    cluster: `${sector.label} Propagation`,
+                    specialty: 'propagation',
+                    type: 'minor',
+                    depth: 10.5,
+                    x: Math.round(propagationEntry.x + awayX * routeLength * progress + perpendicularX * arc),
+                    y: Math.round(propagationEntry.y + awayY * routeLength * progress + perpendicularY * arc),
+                    effects: propagationMinorEffects
+                });
+                routeIds.push(id);
+            }
+            link(propagationEntryId, routeIds[0]);
+            routeIds.slice(1).forEach((id, index) => link(routeIds[index], id));
+            link(routeIds[routeIds.length - 1], propagationNotableId);
+            return routeIds;
+        };
+        addNode({
+            id: propagationNotableId,
+            name: `${sector.label} Propagation Target`,
+            description: '+1 Propagation Target.',
+            sector: sectorId,
+            cluster: `${sector.label} Propagation`,
+            specialty: 'propagation',
+            type: 'notable',
+            depth: 10.5,
+            ...propagationNotablePosition,
+            effects: { propagationTargets: 1 }
+        });
+        const shortRoute = createPropagationRoute('short', 3);
+        const longRoute = createPropagationRoute('long', 4);
+        clusters.push({
+            id: `${sectorId}-propagation-wheel`,
+            sector: sectorId,
+            label: `${sector.label} Propagation`,
+            specialty: 'propagation',
+            x: Math.round(placement.center.x),
+            y: Math.round(placement.center.y),
+            radius: 92,
+            propagation: true,
+            nodeIds: [...shortRoute, ...longRoute, propagationNotableId]
+        });
+    });
+
     const adjacency = Object.fromEntries(nodes.map(node => [node.id, []]));
     const edges = [...links].map(serialized => {
         const [from, to] = serialized.split('|');
@@ -1088,6 +1170,7 @@ function createEmptyPassiveBonuses() {
         comboAttack: 0,
         comboEffectiveness: 0,
         additionalComboAttacks: 0,
+        propagationTargets: 0,
         severedLimbChance: 0,
         maxSeveredLimbs: 0,
         maxSeepingWoundStacks: 0,

--- a/passivesUI.js
+++ b/passivesUI.js
@@ -127,6 +127,7 @@ function formatPassiveEffectName(key, nestedKey = null) {
         deflection: 'Deflection', armorEfficiency: 'Armor Efficiency', weaponEfficiency: 'Weapon Efficiency',
         bionicEfficiency: 'Bionic Efficiency', bionicSync: 'Bionic Sync', comboAttack: 'Combo Attack Chance',
         comboEffectiveness: 'Combo Effectiveness', additionalComboAttacks: 'Additional Combo Attacks',
+        propagationTargets: 'Propagation Targets',
         severedLimbChance: 'Severed Limb Chance', maxSeveredLimbs: 'Maximum Severed Limbs',
         maxSeepingWoundStacks: 'Maximum Seeping Wound Stacks', damageRollFloorBonus: 'Minimum Damage Roll',
         debuffChanceBonus: 'Status Application Chance', debuffDurationBonus: 'Status Duration',

--- a/propagation.js
+++ b/propagation.js
@@ -1,0 +1,267 @@
+// Weapon-family propagation rules, secondary packet construction, and atomic
+// event recording. Gameplay resolves synchronously; combatUI presents the
+// immutable event sequence afterward.
+
+const PROPAGATION_TARGET_CAP = 5;
+const PROPAGATION_TRIGGER_COEFFICIENT = 0.3;
+const PROPAGATION_SLOT_COORDINATES = Object.freeze([
+    Object.freeze({ row: 0, column: 1 }), // top-center
+    Object.freeze({ row: 0, column: 0 }), // top-left
+    Object.freeze({ row: 0, column: 2 }), // top-right
+    Object.freeze({ row: 1, column: 1 }), // bottom-center
+    Object.freeze({ row: 1, column: 0 }), // bottom-left
+    Object.freeze({ row: 1, column: 2 })  // bottom-right
+]);
+
+const WEAPON_PROPAGATION_PROFILES = Object.freeze({
+    blades: Object.freeze({ id: 'cleave', label: 'Cleave', damageCoefficient: 0.55 }),
+    impact: Object.freeze({ id: 'splash', label: 'Splash', damageCoefficient: 0.55 }),
+    sidearms: Object.freeze({ id: 'barrage', label: 'Barrage', damageCoefficient: 0.45 }),
+    rifles: Object.freeze({ id: 'chain', label: 'Chain', damageCoefficient: 0.35 }),
+    projectors: Object.freeze({ id: 'barrage', label: 'Barrage', damageCoefficient: 0.45 }),
+    ordnance: Object.freeze({ id: 'detonation', label: 'Detonation', damageCoefficient: 0.35 }),
+    conduits: Object.freeze({ id: 'nova', label: 'Nova', damageCoefficient: 0.35 })
+});
+
+function getPropagationEntityKey(entity) {
+    if (entity?.isPlayer) return 'player';
+    return String(entity?._combatId || entity?.id || entity?.name || 'unknown');
+}
+
+function getPropagationSlotCoordinate(entity) {
+    return PROPAGATION_SLOT_COORDINATES[Number(entity?._slotIndex)] || null;
+}
+
+function arePropagationSlotsAdjacent(left, right) {
+    const leftCoordinate = getPropagationSlotCoordinate(left);
+    const rightCoordinate = getPropagationSlotCoordinate(right);
+    if (!leftCoordinate || !rightCoordinate) return false;
+    return Math.abs(leftCoordinate.row - rightCoordinate.row)
+        + Math.abs(leftCoordinate.column - rightCoordinate.column) === 1;
+}
+
+function getLivingPropagationEnemies() {
+    return (Array.isArray(encounterEnemies) ? encounterEnemies : [])
+        .filter(candidate => candidate && candidate.currentHealth > 0);
+}
+
+function pickPropagationCandidate(candidates, random = Math.random) {
+    if (!Array.isArray(candidates) || candidates.length === 0) return null;
+    const roll = Math.min(0.999999, Math.max(0, Number(random()) || 0));
+    return candidates[Math.floor(roll * candidates.length)] || candidates[0];
+}
+
+function getPlayerWeaponPropagationProfile(attacker) {
+    if (!attacker?.isPlayer) return null;
+    const weapon = attacker.equipment?.mainHand;
+    if (!weapon) return null;
+    const taxonomy = window.coreboundWeaponTaxonomy?.resolveWeapon?.(weapon);
+    const family = taxonomy?.family || attacker.totalStats?.activeWeaponFamily || weapon.weaponFamily;
+    const definition = WEAPON_PROPAGATION_PROFILES[family];
+    if (!definition) return null;
+    const addedTargets = Math.max(0, Math.floor(Number(attacker.totalStats?.propagationTargets || 0)));
+    return Object.freeze({
+        ...definition,
+        family,
+        targetCount: Math.min(PROPAGATION_TARGET_CAP, 1 + addedTargets),
+        triggerCoefficient: PROPAGATION_TRIGGER_COEFFICIENT
+    });
+}
+
+function getCleavePropagationTargets(primaryTarget) {
+    const primaryCoordinate = getPropagationSlotCoordinate(primaryTarget);
+    if (!primaryCoordinate) return [];
+    const living = getLivingPropagationEnemies().filter(candidate => candidate !== primaryTarget);
+    const byDistance = (left, right, originColumn) => {
+        const leftCoordinate = getPropagationSlotCoordinate(left);
+        const rightCoordinate = getPropagationSlotCoordinate(right);
+        return Math.abs(leftCoordinate.column - originColumn) - Math.abs(rightCoordinate.column - originColumn)
+            || leftCoordinate.column - rightCoordinate.column;
+    };
+    const sameRow = living
+        .filter(candidate => getPropagationSlotCoordinate(candidate)?.row === primaryCoordinate.row)
+        .sort((left, right) => byDistance(left, right, primaryCoordinate.column));
+    const oppositeRow = living
+        .filter(candidate => getPropagationSlotCoordinate(candidate)?.row !== primaryCoordinate.row)
+        .sort((left, right) => byDistance(left, right, primaryCoordinate.column));
+    const oppositeSameColumn = oppositeRow.filter(candidate => (
+        getPropagationSlotCoordinate(candidate)?.column === primaryCoordinate.column
+    ));
+    const oppositeRemaining = oppositeRow.filter(candidate => (
+        getPropagationSlotCoordinate(candidate)?.column !== primaryCoordinate.column
+    ));
+    return [...sameRow, ...oppositeSameColumn, ...oppositeRemaining];
+}
+
+function createPropagationPacket(attacker, target, primaryPacket, profile, eventIndex) {
+    const rawSource = primaryPacket?.metadata?.unmitigatedDamage || primaryPacket?.damage || {};
+    const rawDamage = Object.fromEntries(Object.entries(rawSource).map(([type, amount]) => [
+        type,
+        Math.max(0, Number(amount) || 0) * profile.damageCoefficient
+    ]));
+    const mitigated = typeof mitigateDamageMapForTarget === 'function'
+        ? mitigateDamageMapForTarget(attacker, target, rawDamage)
+        : { damage: rawDamage, total: Math.round(Object.values(rawDamage).reduce((sum, amount) => sum + amount, 0)) };
+    return createDamagePacket({
+        source: attacker,
+        target,
+        kind: 'propagation',
+        damage: mitigated.damage,
+        total: mitigated.total,
+        isCritical: Boolean(primaryPacket?.isCritical),
+        damageRoll: Number(primaryPacket?.damageRoll || 0),
+        mitigated: true,
+        tags: ['hit', 'propagation', profile.id],
+        flags: {
+            animate: false,
+            showDefaultLog: false,
+            handleDefeat: false,
+            applyInherentDebuffs: true
+        },
+        metadata: {
+            unmitigatedDamage: rawDamage,
+            propagation: {
+                family: profile.family,
+                type: profile.id,
+                index: eventIndex,
+                damageCoefficient: profile.damageCoefficient,
+                triggerCoefficient: profile.triggerCoefficient
+            }
+        }
+    });
+}
+
+function resolvePropagationHit(attacker, target, primaryPacket, profile, combatStyleProfile, hitIndex, eventIndex) {
+    const previousProcCoefficient = attacker._activeSkillProcCoefficient;
+    attacker._activeSkillProcCoefficient = profile.triggerCoefficient;
+    try {
+        const packet = createPropagationPacket(attacker, target, primaryPacket, profile, eventIndex);
+        const application = applyDamage(packet);
+        if (typeof runIncomingHitDebuffs === 'function') runIncomingHitDebuffs(attacker, target, packet);
+        if (typeof runSkillHitProcs === 'function') {
+            runSkillHitProcs(attacker, target, packet, combatStyleProfile, hitIndex);
+        }
+        return { packet, application };
+    } finally {
+        attacker._activeSkillProcCoefficient = previousProcCoefficient ?? 1;
+    }
+}
+
+function resolveWeaponPropagation(attacker, primaryTarget, primaryPacket, combatStyleProfile, hitIndex, random = Math.random) {
+    const profile = getPlayerWeaponPropagationProfile(attacker);
+    if (!profile || !primaryTarget || !primaryPacket || primaryPacket.tags?.includes('propagation')) return [];
+    const visualSnapshot = typeof capturePropagationFormationSnapshot === 'function'
+        ? capturePropagationFormationSnapshot(attacker, primaryTarget)
+        : null;
+    const events = [];
+    const defeatedTargets = [];
+    const affected = new Map([[getPropagationEntityKey(primaryTarget), primaryTarget]]);
+    const usedTargets = new Set([getPropagationEntityKey(primaryTarget)]);
+    let chainOrigin = primaryTarget;
+    const cleaveTargets = profile.id === 'cleave' ? getCleavePropagationTargets(primaryTarget) : [];
+
+    for (let eventIndex = 0; eventIndex < profile.targetCount; eventIndex++) {
+        let target = null;
+        let origin = primaryTarget;
+
+        if (profile.id === 'chain') {
+            const candidates = getLivingPropagationEnemies().filter(candidate => (
+                candidate !== chainOrigin && arePropagationSlotsAdjacent(chainOrigin, candidate)
+            ));
+            target = pickPropagationCandidate(candidates, random);
+            origin = chainOrigin;
+        } else if (profile.id === 'splash') {
+            const candidates = [];
+            const candidateIds = new Set();
+            for (const affectedTarget of affected.values()) {
+                for (const candidate of getLivingPropagationEnemies()) {
+                    const candidateId = getPropagationEntityKey(candidate);
+                    if (usedTargets.has(candidateId) || candidateIds.has(candidateId)) continue;
+                    if (!arePropagationSlotsAdjacent(affectedTarget, candidate)) continue;
+                    candidateIds.add(candidateId);
+                    candidates.push({ target: candidate, origin: affectedTarget });
+                }
+            }
+            const selected = pickPropagationCandidate(candidates, random);
+            target = selected?.target || null;
+            origin = selected?.origin || primaryTarget;
+        } else if (profile.id === 'cleave') {
+            target = cleaveTargets.find(candidate => (
+                candidate.currentHealth > 0 && !usedTargets.has(getPropagationEntityKey(candidate))
+            )) || null;
+            origin = events.length > 0 ? events[events.length - 1].targetEntity : primaryTarget;
+        } else {
+            const candidates = getLivingPropagationEnemies().filter(candidate => (
+                !usedTargets.has(getPropagationEntityKey(candidate))
+            ));
+            target = pickPropagationCandidate(candidates, random);
+            origin = profile.id === 'barrage' ? attacker : primaryTarget;
+        }
+
+        if (!target) break;
+        const targetId = getPropagationEntityKey(target);
+        const originId = getPropagationEntityKey(origin);
+        const { packet, application } = resolvePropagationHit(
+            attacker,
+            target,
+            primaryPacket,
+            profile,
+            combatStyleProfile,
+            hitIndex,
+            eventIndex
+        );
+        events.push(Object.freeze({
+            index: eventIndex,
+            type: profile.id,
+            originId,
+            targetId,
+            originSlot: Number(origin?._slotIndex),
+            targetSlot: Number(target?._slotIndex),
+            targetEntity: target,
+            damage: application.appliedDamage,
+            shieldDamage: application.shieldDamage,
+            healthDamage: application.healthDamage,
+            critical: packet.isCritical,
+            targetDefeated: application.targetDefeated
+        }));
+        if (application.targetDefeated) defeatedTargets.push(target);
+        affected.set(targetId, target);
+        if (profile.id !== 'chain') usedTargets.add(targetId);
+        if (profile.id === 'chain') chainOrigin = target;
+    }
+
+    if (events.length > 0) {
+        const immutableEvents = events.map(({ targetEntity, ...event }) => Object.freeze(event));
+        if (typeof queuePropagationPresentation === 'function') {
+            queuePropagationPresentation(Object.freeze({
+                profile,
+                primaryTargetId: getPropagationEntityKey(primaryTarget),
+                snapshot: visualSnapshot,
+                events: Object.freeze(immutableEvents)
+            }), () => {
+                for (const defeatedTarget of defeatedTargets) {
+                    if (typeof handleDefeatedCombatant === 'function') handleDefeatedCombatant(defeatedTarget);
+                }
+            });
+        } else {
+            for (const defeatedTarget of defeatedTargets) {
+                if (typeof handleDefeatedCombatant === 'function') handleDefeatedCombatant(defeatedTarget);
+            }
+        }
+        if (typeof addToCombatLog === 'function') {
+            addToCombatLog(`${profile.label} propagated to ${events.length} additional target${events.length === 1 ? '' : 's'}.`, '#8fe9ff', false);
+        }
+    }
+    return events;
+}
+
+window.coreboundPropagation = Object.freeze({
+    targetCap: PROPAGATION_TARGET_CAP,
+    triggerCoefficient: PROPAGATION_TRIGGER_COEFFICIENT,
+    profiles: WEAPON_PROPAGATION_PROFILES,
+    slotCoordinates: PROPAGATION_SLOT_COORDINATES,
+    getProfile: getPlayerWeaponPropagationProfile,
+    areAdjacent: arePropagationSlotsAdjacent,
+    getCleaveTargets: getCleavePropagationTargets,
+    resolve: resolveWeaponPropagation
+});

--- a/src/runtimeScripts.js
+++ b/src/runtimeScripts.js
@@ -32,6 +32,7 @@ export const RUNTIME_SCRIPTS = [
   'combatState.js',
   'combatController.js',
   'combatEffects.js',
+  'propagation.js',
   'combatResolution.js',
   'delveRewards.js',
   'delveManager.js',

--- a/stats.js
+++ b/stats.js
@@ -243,6 +243,7 @@ function validatePlayerStatSnapshot(stats) {
         'precision', 'deflection', 'healthRegen', 'armorEfficiency', 'weaponEfficiency',
         'bionicEfficiency', 'bionicSync', 'comboAttack', 'comboEffectiveness',
         'additionalComboAttacks', 'maxSeveredLimbs', 'maxSeepingWoundStacks',
+        'propagationTargets',
         'armorPenetration', 'damageRollFloorBonus', 'debuffChanceBonus', 'debuffDurationBonus',
         'statusResistance', 'statusDurationReduction',
         'directDamageMultiplier', 'dotDamageMultiplier', 'damageVsDebuffed', 'damageTakenReduction'
@@ -454,6 +455,7 @@ function applyPassiveStatPackage(stats, effects) {
     for (const key of [
         'armorEfficiency', 'weaponEfficiency', 'bionicEfficiency', 'bionicSync', 'armorPenetration',
         'comboAttack', 'comboEffectiveness', 'additionalComboAttacks',
+        'propagationTargets',
         'severedLimbChance', 'maxSeveredLimbs', 'maxSeepingWoundStacks'
     ]) stats[key] += Number(effects[key] || 0);
     for (const key of [
@@ -532,6 +534,7 @@ function calculatePlayerStats(playerObject) {
     if (stats.comboAttack === undefined) stats.comboAttack = 0;
     if (stats.comboEffectiveness === undefined) stats.comboEffectiveness = 0;
     if (stats.additionalComboAttacks === undefined) stats.additionalComboAttacks = 0;
+    if (stats.propagationTargets === undefined) stats.propagationTargets = 0;
     if (stats.kineticMastery === undefined) stats.kineticMastery = 0;
     if (stats.slashingMastery === undefined) stats.slashingMastery = 0;
     if (stats.severedLimbChance === undefined) stats.severedLimbChance = 0;
@@ -899,7 +902,7 @@ function calculateDamage(attacker, defender, attackContext = null) {
         if (typeof logMessage === 'function') logMessage(`${attacker.name || 'Attacker'} lands a critical hit!`);
     }
 
-    // 4. Apply Defender's Resistances (per damage type)
+    const unmitigatedDamage = {};
     for (let damageType in adjustedBaseDamages) {
         let adjustedBaseDamage = adjustedBaseDamages[damageType];
 
@@ -909,23 +912,12 @@ function calculateDamage(attacker, defender, attackContext = null) {
         // Determine the amount of rolled damage attributed to this type
         let damageAmountForType = rolledDamage * damageProportion;
 
-        // Apply defender's resistance for this damage type
-        let resistanceStat = matchDamageToDefense(damageType); // Assumes matchDamageToDefense exists
-        let resistanceValue = (defender.totalStats && defender.totalStats.defenseTypes) ? (defender.totalStats.defenseTypes[resistanceStat] || 0) : 0;
-
-        // Apply resistance formula (e.g., percentage reduction, capped at 80%)
-        const armorPenetration = Math.max(0, Number(attacker.totalStats.armorPenetration || 0));
-        resistanceValue = Math.max(0, resistanceValue - armorPenetration);
-        resistanceValue = Math.min(resistanceValue, 80); // Cap resistance
-        let damageReductionMultiplier = Math.max(0, 1 - (resistanceValue / 100)); // Ensure multiplier is not negative
-
-        const globalReduction = Math.min(0.75, Math.max(-0.5, Number(defender.totalStats.damageTakenReduction || 0)));
-        let finalDamageForType = damageAmountForType * damageReductionMultiplier * (1 - globalReduction);
-
-        // Store in final breakdown and add to total
-        finalDamageBreakdown[damageType] = Math.round(finalDamageForType * 10) / 10; // Round for display
-        totalDamageDealt += finalDamageForType;
+        unmitigatedDamage[damageType] = damageAmountForType;
     }
+
+    const mitigated = mitigateDamageMapForTarget(attacker, defender, unmitigatedDamage);
+    finalDamageBreakdown = mitigated.damage;
+    totalDamageDealt = mitigated.total;
 
     // Round total damage to nearest whole number
     totalDamageDealt = Math.round(totalDamageDealt);
@@ -939,9 +931,32 @@ function calculateDamage(attacker, defender, attackContext = null) {
         isCritical: isCriticalHit,
         damageRoll: damagePercentage,
         mitigated: true,
-        tags: ctx.tags || ['hit']
+        tags: ctx.tags || ['hit'],
+        metadata: { unmitigatedDamage }
     });
 }
+
+// Applies the target-facing half of hit calculation to an already rolled typed
+// damage map. Propagation reuses the primary hit's roll and critical result,
+// then calls this for each secondary target so their defenses remain independent.
+function mitigateDamageMapForTarget(attacker, defender, rawDamage = {}) {
+    const damage = {};
+    let total = 0;
+    for (const [damageType, rawAmount] of Object.entries(rawDamage || {})) {
+        const amount = Math.max(0, Number(rawAmount) || 0);
+        const resistanceStat = matchDamageToDefense(damageType);
+        let resistance = Number(defender?.totalStats?.defenseTypes?.[resistanceStat] || 0);
+        resistance -= Math.max(0, Number(attacker?.totalStats?.armorPenetration || 0));
+        resistance = Math.min(80, Math.max(0, resistance));
+        const globalReduction = Math.min(0.75, Math.max(-0.5, Number(defender?.totalStats?.damageTakenReduction || 0)));
+        const finalAmount = amount * (1 - resistance / 100) * (1 - globalReduction);
+        damage[damageType] = Math.round(finalAmount * 10) / 10;
+        total += finalAmount;
+    }
+    return { damage, total: Math.round(total) };
+}
+
+window.mitigateDamageMapForTarget = mitigateDamageMapForTarget;
 
 // Calculate enemy's total stats (simpler version, assumes enemy object has base stats)
 function calculateEnemyStats(enemyObject) {

--- a/style.css
+++ b/style.css
@@ -6237,7 +6237,8 @@ hr {
 }
 
 .locations-scroll-container {
-    max-height: 345px !important;
+    max-height: none !important;
+    overflow: visible !important;
 }
 
 .location-progression-notice {
@@ -6435,6 +6436,7 @@ hr {
     z-index: 2;
     display: grid;
     grid-template-columns: 94px minmax(0, 1fr);
+    grid-template-rows: 27px repeat(3, minmax(0, 1fr));
     gap: 9px 13px;
     min-height: 188px;
     padding: 13px;
@@ -6449,6 +6451,14 @@ hr {
 
 .player-combat-card .combat-card-portrait {
     grid-row: 1 / 5;
+}
+
+.player-combat-card > h2 {
+    align-self: center;
+    min-height: 24px;
+    padding-top: 2px;
+    overflow: visible;
+    line-height: 1.35;
 }
 
 .combat-card h2,

--- a/style.css
+++ b/style.css
@@ -5209,6 +5209,28 @@ hr {
     margin-bottom: 30px;
 }
 
+.codex-subpages { display: flex; gap: 8px; margin: 0 0 18px; }
+.codex-subpages button {
+    padding: 8px 14px;
+    border: 1px solid rgba(75, 220, 240, 0.35);
+    border-radius: 5px;
+    background: rgba(5, 31, 48, 0.82);
+    color: #a9cbd5;
+    font-family: 'Orbitron', sans-serif;
+    cursor: pointer;
+}
+.codex-subpages button.active { border-color: #55e4f7; color: #fff; box-shadow: 0 0 12px rgba(85, 228, 247, 0.18); }
+.codex-weapon-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 12px; }
+.codex-weapon-family { padding: 14px; border: 1px solid rgba(93, 206, 224, 0.26); border-radius: 7px; background: rgba(3, 21, 34, 0.8); }
+.codex-weapon-family h3 { margin: 0 0 8px; color: #dffaff; }
+.codex-weapon-family p { min-height: 44px; margin: 0 0 10px; color: #9bbbc5; }
+.codex-weapon-family strong { color: #7de8f5; font-size: 12px; }
+.codex-propagation-table { width: 100%; border-collapse: collapse; color: #c8e5ec; }
+.codex-propagation-table th,
+.codex-propagation-table td { padding: 10px 12px; border-bottom: 1px solid rgba(102, 211, 228, 0.18); text-align: left; }
+.codex-propagation-table th { color: #75e5f2; font: 700 11px 'Orbitron', sans-serif; text-transform: uppercase; }
+.codex-propagation-table td:nth-child(3) { color: #ffe169; font-weight: 700; white-space: nowrap; }
+
 .codex-subtitle {
     color: #66ccff;
     font-size: 18px;
@@ -6299,6 +6321,70 @@ hr {
     background: linear-gradient(90deg, transparent, rgba(90, 205, 232, 0.22), transparent);
     pointer-events: none;
 }
+
+.propagation-effects-layer {
+    position: absolute;
+    inset: 0;
+    z-index: 6;
+    overflow: hidden;
+    pointer-events: none;
+}
+
+.propagation-effect { position: absolute; display: block; pointer-events: none; }
+.propagation-line {
+    height: 4px;
+    transform-origin: 0 50%;
+    border-radius: 999px;
+    opacity: 0.95;
+    background: linear-gradient(90deg, transparent 0 5%, #d9fbff 45%, #69dff5 70%, transparent 100%);
+    filter: drop-shadow(0 0 5px #65eaff);
+    clip-path: inset(0 100% 0 0);
+    animation: propagation-flight 145ms ease-out forwards;
+}
+.propagation-line.propagation-chain { height: 3px; background: repeating-linear-gradient(90deg, #fff 0 7px, #63d9ff 8px 14px); animation-duration: 90ms; }
+.propagation-line.propagation-cleave { height: 7px; background: linear-gradient(90deg, transparent, #fff 40%, #ff708d 68%, transparent); }
+.propagation-line.propagation-barrage { height: 3px; background: linear-gradient(90deg, transparent, #fff 72%, #ffd166 84%, transparent); }
+.propagation-line.propagation-detonation { height: 6px; background: linear-gradient(90deg, transparent, #ffdf77, #ff6b35); }
+.propagation-line.arrived { opacity: 0; transition: opacity 70ms ease; }
+
+.propagation-impact {
+    width: 22px;
+    height: 22px;
+    margin: -11px;
+    border: 3px solid #d9fbff;
+    border-radius: 50%;
+    box-shadow: 0 0 12px #5de9ff, inset 0 0 8px #fff;
+    animation: propagation-impact 360ms ease-out forwards;
+}
+.propagation-impact.propagation-cleave { border-color: #ff708d; border-radius: 2px; transform: rotate(45deg); }
+.propagation-impact.propagation-splash { border-color: #ffb45e; }
+.propagation-impact.propagation-detonation { border-color: #ff6b35; box-shadow: 0 0 24px #ff6b35; }
+.propagation-impact.propagation-nova { border-color: #b58cff; box-shadow: 0 0 22px #b58cff; }
+.propagation-damage {
+    z-index: 2;
+    transform: translate(-50%, -50%);
+    color: #bff8ff;
+    font: 700 15px 'Orbitron', sans-serif;
+    text-shadow: 0 2px 4px #000, 0 0 7px #42dbff;
+    animation: propagation-number 600ms ease-out forwards;
+}
+.propagation-damage.critical { color: #ffe169; font-size: 18px; text-shadow: 0 2px 4px #000, 0 0 8px #ffd23f; }
+.propagation-pulse {
+    width: 30px;
+    height: 30px;
+    margin: -15px;
+    border: 3px solid #b58cff;
+    border-radius: 50%;
+    box-shadow: 0 0 20px #b58cff;
+    animation: propagation-pulse 280ms ease-out forwards;
+}
+.propagation-pulse.propagation-detonation { border-color: #ff813d; box-shadow: 0 0 24px #ff813d; }
+.enemy-combat-card.defeated.propagation-pending { opacity: 1; filter: none; }
+
+@keyframes propagation-flight { to { clip-path: inset(0 0 0 0); } }
+@keyframes propagation-impact { from { transform: scale(0.25); opacity: 1; } to { transform: scale(2.6); opacity: 0; } }
+@keyframes propagation-number { from { transform: translate(-50%, -20%) scale(0.8); opacity: 0; } 20% { opacity: 1; } to { transform: translate(-50%, -125%) scale(1); opacity: 0; } }
+@keyframes propagation-pulse { from { transform: scale(0.2); opacity: 1; } to { transform: scale(9); opacity: 0; } }
 
 .combat-stage-tools {
     position: absolute;

--- a/tests/repository.test.mjs
+++ b/tests/repository.test.mjs
@@ -2161,10 +2161,12 @@ test('delve combat stage uses compact cards, six target slots, and closed utilit
   }
 
   const ui = read('combatUI.js');
+  const controller = read('combatController.js');
   const styles = read('style.css');
   assert.match(ui, /for \(let slot = 0; slot < 6; slot\+\+\)/);
   assert.match(ui, /enemy-attack-progress-bar/);
-  assert.match(read('combatController.js'), /setAttackProgressBar\(attacker, Math\.min\(\(timer \/ nextAttack\) \* 100, 100\)\)/);
+  assert.match(controller, /setAttackProgressBar\(attacker, Math\.min\(\(timer \/ nextAttack\) \* 100, 100\)\)/);
+  assert.doesNotMatch(controller, /isPropagationPresentationBusy/, 'propagation visuals must not pause combat timers');
   assert.match(ui, /selectEnemyTarget\(combatId\)/);
   assert.match(ui, /function setDelveCombatUIActive\(active\)/);
   assert.match(ui, /if \(!active\) closeCombatDrawers\(\)/);
@@ -2172,7 +2174,17 @@ test('delve combat stage uses compact cards, six target slots, and closed utilit
   assert.match(styles, /\.enemy-combat-card:nth-child\(1\)\s*\{\s*grid-area:\s*top-center/);
   assert.match(styles, /\.enemy-combat-card:nth-child\(6\)\s*\{\s*grid-area:\s*bottom-right/);
   assert.match(styles, /#player-stats\.player-combat-card\s*\{[^}]*width:\s*min\(364px, 100%\)[^}]*height:\s*188px/s);
+  assert.match(styles, /\.player-combat-card\s*\{[^}]*grid-template-rows:\s*27px repeat\(3, minmax\(0, 1fr\)\)/s);
+  assert.match(styles, /\.player-combat-card > h2\s*\{[^}]*overflow:\s*visible/s);
   assert.match(styles, /\.enemy-combat-card\s*\{[^}]*height:\s*188px/s);
+});
+
+test('delve deployment grid expands without an internal scrollbar', () => {
+  const ui = read('delveUI.js');
+  const styles = read('style.css');
+  assert.doesNotMatch(ui, /locationScrollContainer\.style\.(?:overflow|maxHeight)/);
+  assert.doesNotMatch(ui, /locations-scroll-container::-(?:webkit-)?scrollbar/);
+  assert.match(styles, /\.locations-scroll-container\s*\{[^}]*max-height:\s*none\s*!important[^}]*overflow:\s*visible\s*!important/s);
 });
 
 test('encounter sizing rises by area level while retaining smaller max-level groups', () => {

--- a/tests/repository.test.mjs
+++ b/tests/repository.test.mjs
@@ -40,6 +40,7 @@ const COMBAT_RUNTIME_FILES = [
   'combatState.js',
   'combatController.js',
   'combatEffects.js',
+  'propagation.js',
   'combatResolution.js',
   'delveRewards.js',
   'delveManager.js',
@@ -372,6 +373,17 @@ test('radial passive tree is connected, stable, and honors allocation/refund rul
         familyTargets: PASSIVE_TREE_SECTOR_ORDER.map(sector => [...new Set(passives.filter(node => node.sector === sector && node.specialty === 'family').map(node => node.target))]),
         tagTargets: PASSIVE_TREE_SECTOR_ORDER.map(sector => [...new Set(passives.filter(node => node.sector === sector && node.specialty === 'tag').map(node => node.target))]),
         styleTargets: PASSIVE_TREE_SECTOR_ORDER.map(sector => [...new Set(passives.filter(node => node.sector === sector && node.specialty === 'style').map(node => node.target))]),
+        propagationWheels: PASSIVE_TREE_SECTOR_ORDER.map(sector => {
+          const notable = passives.find(node => node.id === sector + '-propagation-notable');
+          const minors = passives.filter(node => node.sector === sector && node.specialty === 'propagation' && node.type === 'minor');
+          return {
+            notableEffects: notable?.effects,
+            minorEffects: minors.map(node => node.effects),
+            minorCount: minors.length,
+            notableConnections: notable?.connections.length,
+            matchingDamage: minors.every(node => node.effects.damageTypes?.[sector] === 8 && Object.keys(node.effects).length === 1)
+          };
+        }),
         bridgeSeams: PASSIVE_BRIDGE_DEFINITIONS.map(bridge => {
           const nodes = passives.filter(node => node.sector === 'bridge'
             && node.sectors?.join('|') === bridge.sectors.join('|'));
@@ -392,16 +404,19 @@ test('radial passive tree is connected, stable, and honors allocation/refund rul
     })()`
   );
   assert.equal(result.validation.valid, true, result.validation.errors.join('; '));
-  assert.equal(result.nodeCount, 1490);
-  assert.equal(result.edgeCount, 1764);
-  assert.equal(result.clusterCount, 147);
-  assert.equal(result.notableCount, 210);
+  assert.equal(result.nodeCount, 1546);
+  assert.equal(result.edgeCount, 1827);
+  assert.equal(result.clusterCount, 154);
+  assert.equal(result.notableCount, 217);
   assert.equal(result.keystones, 35);
   assert.equal(result.jewels, 0);
   assert.equal(result.travelDegrees.every(degree => degree >= 3), true, 'travel roads still contain forced single-lane rail nodes');
   assert.equal(result.familyTargets.every(targets => targets.length === 7), true, 'weapon families are not distributed through every sector');
   assert.equal(result.tagTargets.every(targets => targets.length === 4), true, 'weapon tags are not distributed through every sector');
   assert.equal(result.styleTargets.every(targets => targets.length === 4), true, 'combat styles are not distributed through every sector');
+  assert.equal(result.propagationWheels.every(wheel => wheel.minorCount === 7 && wheel.notableConnections === 2), true, 'a propagation wheel lost its three/four route topology');
+  assert.equal(result.propagationWheels.every(wheel => wheel.notableEffects?.propagationTargets === 1 && Object.keys(wheel.notableEffects).length === 1), true, 'a propagation notable has the wrong effect package');
+  assert.equal(result.propagationWheels.every(wheel => wheel.matchingDamage), true, 'a propagation route minor is not exactly 8% matching damage');
   assert.equal(result.bridgeSeams.every(seam => seam.count === 2), true, 'an outer sector seam contains more than two passives');
   assert.equal(result.bridgeSeams.every(seam => seam.types.every(type => type === 'notable')), true, 'outer sector seams are not exclusively notables');
   assert.equal(result.bridgeSeams.every(seam => seam.names.join('|') === seam.expectedNames.join('|')), true, 'an outer sector seam lost its authored notable identities');
@@ -437,7 +452,7 @@ test('passive tree renderer uses a culled canvas graph with an incremental SVG i
   const overviewTypes = new Set(['origin', 'gateway', 'travel', 'connector', 'bridge', 'notable', 'keystone']);
   const overviewNodeCount = passiveDefinitions.filter(node => overviewTypes.has(node.type)).length;
 
-  assert.equal(overviewNodeCount, 496, 'overview detail unexpectedly includes the full minor-node population');
+  assert.equal(overviewNodeCount, 503, 'overview detail unexpectedly includes the full minor-node population');
   assert.ok(overviewNodeCount < passiveDefinitions.length / 2, 'overview detail does not substantially reduce live node count');
   assert.match(uiSource, /id="passive-tree-canvas"/, 'passive graph canvas layer is missing');
   assert.match(uiSource, /canvas\.getContext\('2d'\)/, 'passive graph does not initialize a 2D canvas renderer');
@@ -2237,6 +2252,96 @@ test('multi-enemy encounter rewards share the original encounter budget', () => 
   assert.match(combat, /Number\.isFinite\(target\._experienceReward\)/);
   assert.match(read('lootHandler.js'), /dropChance \*= Math\.max\(0, Number\(enemy\._rewardScale \?\? 1\)\)/);
   assert.match(read('delveRewards.js'), /dropRate \* rewardScale/);
+});
+
+test('weapon propagation profiles enforce coefficients, geometry, uniqueness, and Chain revisits', () => {
+  const rawResult = evaluateClassic(
+    'propagation.js',
+    `(() => {
+      const makeEnemies = () => Array.from({ length: 6 }, (_, slot) => ({
+        name: 'E' + slot,
+        id: 'e' + slot,
+        _combatId: 'e' + slot,
+        _slotIndex: slot,
+        currentHealth: 100,
+        currentShield: 0,
+        totalStats: { defenseTypes: {} }
+      }));
+      const packet = {
+        metadata: { unmitigatedDamage: { kinetic: 100 } },
+        damage: { kinetic: 100 },
+        total: 100,
+        isCritical: true,
+        damageRoll: 0.73,
+        tags: ['hit']
+      };
+      const resolveFamily = (family, primarySlot) => {
+        encounterEnemies = makeEnemies();
+        const attacker = {
+          isPlayer: true,
+          name: 'Player',
+          equipment: { mainHand: { weaponFamily: family } },
+          totalStats: { propagationTargets: 4, armorPenetration: 0 },
+          effects: []
+        };
+        let presentation = null;
+        queuePropagationPresentation = sequence => { presentation = sequence; };
+        window.coreboundPropagation.resolve(attacker, encounterEnemies[primarySlot], packet, { hitCount: 1, procOnHit: 'all', procOnCritical: 'all' }, 0, () => 0);
+        return presentation.events.map(event => event.targetId);
+      };
+      return {
+        profiles: window.coreboundPropagation.profiles,
+        cap: window.coreboundPropagation.targetCap,
+        trigger: window.coreboundPropagation.triggerCoefficient,
+        cleave: resolveFamily('blades', 0),
+        splash: resolveFamily('impact', 1),
+        barrage: resolveFamily('sidearms', 0),
+        chain: resolveFamily('rifles', 1),
+        nova: resolveFamily('conduits', 0)
+      };
+    })()`,
+    {
+      encounterEnemies: [],
+      queuePropagationPresentation: () => {},
+      capturePropagationFormationSnapshot: () => ({ anchors: {} }),
+      mitigateDamageMapForTarget: (_attacker, _target, damage) => ({
+        damage,
+        total: Math.round(Object.values(damage).reduce((sum, amount) => sum + amount, 0))
+      }),
+      createDamagePacket: input => ({ ...input }),
+      applyDamage: packet => ({
+        appliedDamage: packet.total,
+        shieldDamage: 0,
+        healthDamage: packet.total,
+        targetDefeated: false
+      }),
+      runIncomingHitDebuffs: () => {},
+      runSkillHitProcs: () => {},
+      addToCombatLog: () => {},
+      window: {
+        coreboundWeaponTaxonomy: { resolveWeapon: weapon => ({ family: weapon.weaponFamily }) }
+      }
+    }
+  );
+  const result = JSON.parse(JSON.stringify(rawResult));
+
+  assert.equal(result.cap, 5);
+  assert.equal(result.trigger, 0.3);
+  assert.deepEqual(Object.fromEntries(Object.entries(result.profiles).map(([family, profile]) => [family, [profile.id, profile.damageCoefficient]])), {
+    blades: ['cleave', 0.55],
+    impact: ['splash', 0.55],
+    sidearms: ['barrage', 0.45],
+    rifles: ['chain', 0.35],
+    projectors: ['barrage', 0.45],
+    ordnance: ['detonation', 0.35],
+    conduits: ['nova', 0.35]
+  });
+  assert.deepEqual(result.cleave, ['e1', 'e2', 'e3', 'e4', 'e5']);
+  assert.equal(new Set(result.splash).size, 5);
+  assert.equal(new Set(result.barrage).size, 5);
+  assert.equal(new Set(result.nova).size, 5);
+  assert.deepEqual(result.chain, ['e0', 'e1', 'e0', 'e1', 'e0']);
+  assert.match(read('debuffs.js'), /debuffChance \* triggerCoefficient/);
 });
 
 test('consumable combat debuffs carry the approved mechanics', () => {


### PR DESCRIPTION
## Summary
- add intrinsic weapon-family propagation with approved targeting, coefficients, trigger scaling, and combat presentation
- add seven passive-tree propagation wheels and expose Propagation Targets in the stat UI
- add Weapon Types and Propagation Codex pages
- keep combat timers advancing during propagation visuals and reset the player attack bar cleanly
- prevent player-name clipping and let the Delve deployment grid expand without an internal scrollbar

## Validation
- `node --test tests/*.test.mjs` (77/77 passing)
- `vite build`
- `node scripts/analyze-progression-balance.mjs`